### PR TITLE
Fix MOB-1982 crashes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionCode="1511031052" android:versionName="2.9-SNAPSHOT" package="org.exoplatform">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionCode="1511131411" android:versionName="2.9-SNAPSHOT" package="org.exoplatform">
     <supports-screens android:smallScreens="false"/>
 
     <!-- Application Permissions -->
@@ -93,11 +93,11 @@
         <!--
            Social (Activity Stream, Details, Composer, Likers)
           -->
-        <activity android:configChanges="keyboardHidden|orientation" android:name=".ui.social.SocialTabsActivity" android:parentActivityName=".ui.HomeActivity" android:theme="@style/Theme.PageIndicatorDefaults">
+        <activity android:name=".ui.social.SocialTabsActivity" android:parentActivityName=".ui.HomeActivity" android:theme="@style/Theme.PageIndicatorDefaults">
             <!-- For API v14 & 15 -->
             <meta-data android:name="android.support.PARENT_ACTIVITY" android:value=".ui.HomeActivity"/>
         </activity>
-        <activity android:configChanges="keyboardHidden|orientation" android:name=".ui.social.SocialDetailActivity" android:parentActivityName=".ui.social.SocialTabsActivity">
+        <activity android:name=".ui.social.SocialDetailActivity" android:parentActivityName=".ui.social.SocialTabsActivity">
             <!-- For API v14 & 15 -->
             <meta-data android:name="android.support.PARENT_ACTIVITY" android:value=".ui.social.SocialTabsActivity"/>
         </activity>

--- a/src/org/exoplatform/controller/document/DocumentAdapter.java
+++ b/src/org/exoplatform/controller/document/DocumentAdapter.java
@@ -24,6 +24,8 @@ import org.exoplatform.R;
 import org.exoplatform.model.ExoFile;
 import org.exoplatform.ui.DocumentActionDialog;
 import org.exoplatform.ui.DocumentActivity;
+import org.exoplatform.utils.CompatibleFileOpen.FileOpenRequest;
+import org.exoplatform.utils.CompatibleFileOpen.FileOpenRequestResult;
 import org.exoplatform.utils.ExoConstants;
 import org.exoplatform.utils.ExoDocumentUtils;
 import org.exoplatform.widget.UnreadableFileDialog;
@@ -146,7 +148,10 @@ public class DocumentAdapter extends BaseAdapter {
             if (ExoDocumentUtils.isForbidden(myFile.nodeType)) {
               new UnreadableFileDialog(_mContext, null).show();
             } else {
-              ExoDocumentUtils.fileOpen(_mContext, myFile.nodeType, myFile.path, myFile.name);
+              FileOpenRequest fileOpenReq = ExoDocumentUtils.fileOpen(_mContext, myFile.nodeType, myFile.path, myFile.name);
+              if (fileOpenReq.mResult == FileOpenRequestResult.EXTERNAL) {
+                DocumentActivity._documentActivityInstance.mFileOpenController = fileOpenReq.mFileOpenController;
+              }
             }
           } else {
             DocumentActivity._documentActivityInstance.loadFolderContent(myFile);

--- a/src/org/exoplatform/controller/document/DocumentLoadTask.java
+++ b/src/org/exoplatform/controller/document/DocumentLoadTask.java
@@ -51,6 +51,8 @@ public class DocumentLoadTask extends AsyncTask<Integer, Void, Integer> {
   private static final int      RESULT_TIMEOUT = 3;
 
   private static final int      RESULT_FALSE   = 4;
+  
+  private static final int      RESULT_CANCELED   = 5;
 
   // LOG TAG
   private static final String   LOG_TAG        = "eXo____DocumentLoadTask____";
@@ -170,9 +172,11 @@ public class DocumentLoadTask extends AsyncTask<Integer, Void, Integer> {
 
       }
 
-      /*
-       * Get folder content
-       */
+//    Stop execution if the task was canceled
+      if (isCancelled())
+        return RESULT_CANCELED;
+      
+//    Get folder content
       if (result == true) {
         loadedFolder = ExoDocumentUtils.getPersonalDriveContent(documentActivity, sourceFile);
         return RESULT_OK;
@@ -189,7 +193,8 @@ public class DocumentLoadTask extends AsyncTask<Integer, Void, Integer> {
   @Override
   public void onCancelled() {
     super.onCancelled();
-    _progressDialog.dismiss();
+    if (_progressDialog.isAttachedToWindow())
+      _progressDialog.dismiss();
   }
 
   @Override
@@ -214,8 +219,8 @@ public class DocumentLoadTask extends AsyncTask<Integer, Void, Integer> {
     } else if (result == RESULT_FALSE) {
       new WarningDialog(documentActivity, titleString, contentWarningString, okString).show();
     }
-
-    _progressDialog.dismiss();
+    if (_progressDialog.isAttachedToWindow())
+      _progressDialog.dismiss();
   }
 
 }

--- a/src/org/exoplatform/controller/home/SocialLoadTask.java
+++ b/src/org/exoplatform/controller/home/SocialLoadTask.java
@@ -118,7 +118,7 @@ public abstract class SocialLoadTask extends AsyncTask<Integer, Void, ArrayList<
    * </ul>
    */
   public ArrayList<SocialActivityInfo> doInBackground(Integer... params) {
-    Log.i(TAG, "load social activities - number: " + params[0] + " - type: " + params[1]);
+    Log.i(TAG, "Loading Social activities - number: " + params[0] + " - type: " + params[1]);
 
     try {
       ArrayList<SocialActivityInfo> listActivity = new ArrayList<SocialActivityInfo>();
@@ -177,11 +177,11 @@ public abstract class SocialLoadTask extends AsyncTask<Integer, Void, ArrayList<
 
       return listActivity;
     } catch (SocialClientLibException e) {
-      Log.d(TAG, "SocialClientLibException: ", e.getLocalizedMessage());
+      Log.d(TAG, e.getLocalizedMessage());
       return null;
     } catch (RuntimeException e) {
       // Cannot replace because SocialClientLib can throw many kind of exceptions like ServerException, UnsupportMethod, etc
-      Log.d(TAG, "RuntimeException: ", e.getLocalizedMessage());
+      Log.d(TAG, e.getLocalizedMessage());
       return null;
     }
   }
@@ -204,6 +204,7 @@ public abstract class SocialLoadTask extends AsyncTask<Integer, Void, ArrayList<
   }
 
   private void stopLoadingIndicator() {
+    // get the loading indicator of the SocialTabsActivity
     if (loaderItem == null && feedType != HomeController.FLIPPER_VIEW && SocialTabsActivity.instance != null)
       loaderItem = SocialTabsActivity.instance.loaderItem;
 

--- a/src/org/exoplatform/controller/social/SocialDetailController.java
+++ b/src/org/exoplatform/controller/social/SocialDetailController.java
@@ -21,6 +21,8 @@ package org.exoplatform.controller.social;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
+import com.squareup.picasso.Picasso;
+
 import org.exoplatform.R;
 import org.exoplatform.model.SocialActivityInfo;
 import org.exoplatform.model.SocialCommentInfo;
@@ -38,8 +40,6 @@ import org.exoplatform.utils.image.RoundedCornersTranformer;
 import org.exoplatform.widget.CommentItemLayout;
 import org.exoplatform.widget.ConnectionErrorDialog;
 import org.exoplatform.widget.SocialActivityDetailsItem;
-
-import com.squareup.picasso.Picasso;
 
 import android.content.Context;
 import android.content.Intent;
@@ -145,13 +145,12 @@ public class SocialDetailController {
     int commentListSize = commentList.size();
     if (commentListSize > 0) {
       SocialDetailActivity.socialDetailActivity.setEmptyView(View.GONE);
-      LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
+      LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
       commentLayoutWrap.removeAllViews();
       for (int i = 0; i < commentListSize; i++) {
         SocialCommentInfo comment = commentList.get(i);
         CommentItemLayout commentItem = new CommentItemLayout(mContext);
         String avatarUrl = comment.getImageUrl();
-
         if (avatarUrl == null) {
           commentItem.comAvatarImage.setImageResource(ExoConstants.DEFAULT_AVATAR);
         } else {
@@ -175,7 +174,6 @@ public class SocialDetailController {
     } else {
       SocialDetailActivity.socialDetailActivity.setEmptyView(View.VISIBLE);
     }
-
   }
 
   public void setLikedState() {
@@ -188,7 +186,7 @@ public class SocialDetailController {
 
   public void setComponentInfo(SocialActivityInfo streamInfo) {
     setLikedState();
-    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
+    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
     contentDetailLayout.removeAllViews();
     SocialActivityDetailsItem item = new SocialActivityDetailsItem(mContext, streamInfo, true);
     SocialActivityUtil.setTextLinkify(item.textViewMessage);
@@ -267,5 +265,4 @@ public class SocialDetailController {
   public void onLikePress(int pos) {
     onLikeLoad(activityId, pos);
   }
-
 }

--- a/src/org/exoplatform/controller/social/SocialDetailLoadTask.java
+++ b/src/org/exoplatform/controller/social/SocialDetailLoadTask.java
@@ -216,7 +216,6 @@ public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
   @Override
   protected void onCancelled(Integer result) {
     detailController.setLoading(false);
-    super.onCancelled(result);
   }
 
   private void changeLanguage() {

--- a/src/org/exoplatform/controller/social/SocialDetailLoadTask.java
+++ b/src/org/exoplatform/controller/social/SocialDetailLoadTask.java
@@ -53,6 +53,7 @@ import android.os.AsyncTask;
 import android.view.View;
 
 public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
+  
   private RestActivity                 selectedRestActivity;
 
   private LinkedList<SocialLikeInfo>   likeLinkedList    = new LinkedList<SocialLikeInfo>();
@@ -86,7 +87,6 @@ public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
     detailController = controller;
     currentPosition = pos;
     changeLanguage();
-
   }
 
   @Override
@@ -146,7 +146,6 @@ public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
             socialLike.setLikeName(likeName);
             likeLinkedList.add(socialLike);
           }
-
         }
       }
 
@@ -212,13 +211,12 @@ public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
     }
     detailController.setLoading(false);
     SocialDetailActivity.socialDetailActivity.startScreen.setVisibility(View.GONE);
-
   }
 
   @Override
-  protected void onCancelled() {
+  protected void onCancelled(Integer result) {
     detailController.setLoading(false);
-    super.onCancelled();
+    super.onCancelled(result);
   }
 
   private void changeLanguage() {
@@ -227,7 +225,5 @@ public class SocialDetailLoadTask extends AsyncTask<Boolean, Void, Integer> {
     okString = resource.getString(R.string.OK);
     titleString = resource.getString(R.string.Warning);
     detailsErrorStr = resource.getString(R.string.DetailsNotAvaiable);
-
   }
-
 }

--- a/src/org/exoplatform/ui/DocumentActivity.java
+++ b/src/org/exoplatform/ui/DocumentActivity.java
@@ -29,6 +29,7 @@ import org.exoplatform.model.ExoFile;
 import org.exoplatform.singleton.AccountSetting;
 import org.exoplatform.singleton.DocumentHelper;
 import org.exoplatform.ui.social.SelectedImageActivity;
+import org.exoplatform.utils.CrashUtils;
 import org.exoplatform.utils.ExoConnectionUtils;
 import org.exoplatform.utils.ExoConstants;
 import org.exoplatform.utils.PhotoUtils;
@@ -322,11 +323,15 @@ public class DocumentActivity extends Activity {
 
   public void updateContent(ExoFile newFolder) {
     _fileForCurrentActionBar = newFolder;
-    List<ExoFile> documentList = newFolder.children;
     if ("".equals(_fileForCurrentActionBar.name)) {
       setTitle(getResources().getString(R.string.Documents));
     } else {
       setTitle(_fileForCurrentActionBar.getName());
+    }
+    List<ExoFile> documentList = newFolder.children;
+    if (documentList == null) {
+      CrashUtils.loge(TAG, String.format("Null list of children for folder '%s'", newFolder.path));
+      documentList = new ArrayList<ExoFile>(0);
     }
     if (documentList.size() == 0) {
       setEmptyView(View.VISIBLE);

--- a/src/org/exoplatform/ui/DocumentActivity.java
+++ b/src/org/exoplatform/ui/DocumentActivity.java
@@ -222,8 +222,7 @@ public class DocumentActivity extends Activity {
        * @param: parent The parent folder
        * @param: documentList The parents list file
        */
-
-      if (_fileForCurrentActionBar.name.equals("")) {
+      if ("".equals(_fileForCurrentActionBar.name)) {
         _documentActivityInstance = null;
         finish();
       } else {
@@ -237,9 +236,7 @@ public class DocumentActivity extends Activity {
          */
         updateContent(getParentFolderAndChildren());
       }
-
     }
-
   }
 
   private ExoFile getParentFolderAndChildren() {
@@ -309,6 +306,18 @@ public class DocumentActivity extends Activity {
       mLoadTask.cancel(true);
       mLoadTask = null;
     }
+  }
+  
+  @Override
+  protected void onPause() {
+    onCancelLoad();
+    super.onPause();
+  }
+  
+  @Override
+  protected void onDestroy() {
+    _documentActivityInstance = null;
+    super.onDestroy();
   }
 
   private void init() {

--- a/src/org/exoplatform/ui/DocumentActivity.java
+++ b/src/org/exoplatform/ui/DocumentActivity.java
@@ -29,6 +29,7 @@ import org.exoplatform.model.ExoFile;
 import org.exoplatform.singleton.AccountSetting;
 import org.exoplatform.singleton.DocumentHelper;
 import org.exoplatform.ui.social.SelectedImageActivity;
+import org.exoplatform.utils.CompatibleFileOpen;
 import org.exoplatform.utils.CrashUtils;
 import org.exoplatform.utils.ExoConnectionUtils;
 import org.exoplatform.utils.ExoConstants;
@@ -101,6 +102,8 @@ public class DocumentActivity extends Activity {
   public DocumentAdapter         _documentAdapter;
 
   private DocumentLoadTask       mLoadTask;
+  
+  public CompatibleFileOpen      mFileOpenController;
 
   private View                   empty_stub;
 
@@ -150,7 +153,6 @@ public class DocumentActivity extends Activity {
     outState.putParcelable(DOCUMENT_HELPER, DocumentHelper.getInstance());
     outState.putParcelable(ACCOUNT_SETTING, AccountSetting.getInstance());
     outState.putParcelable(CURRENT_FILE, _fileForCurrentActionBar);
-
   }
 
   @Override
@@ -292,7 +294,7 @@ public class DocumentActivity extends Activity {
   private void onLoad(ExoFile source, String destination, int action) {
     if (ExoConnectionUtils.isNetworkAvailableExt(this)) {
       if (mLoadTask == null || mLoadTask.getStatus() == DocumentLoadTask.Status.FINISHED) {
-        Log.i("DocumentLoadTask", "onLoad");
+        Log.i(TAG, "Starting Document Load Task");
         mLoadTask = (DocumentLoadTask) new DocumentLoadTask(this, source, destination, action).execute();
       }
     } else {
@@ -302,9 +304,12 @@ public class DocumentActivity extends Activity {
 
   public void onCancelLoad() {
     if (mLoadTask != null && mLoadTask.getStatus() == DocumentLoadTask.Status.RUNNING) {
-      Log.i("DocumentLoadTask", "onCancelLoad");
+      Log.i(TAG, "Canceling Document Load Task");
       mLoadTask.cancel(true);
       mLoadTask = null;
+    }
+    if (mFileOpenController != null) {
+      mFileOpenController.onCancelLoad();
     }
   }
   

--- a/src/org/exoplatform/ui/login/LoginProxy.java
+++ b/src/org/exoplatform/ui/login/LoginProxy.java
@@ -20,8 +20,6 @@ package org.exoplatform.ui.login;
 
 import java.util.ArrayList;
 
-import com.crashlytics.android.Crashlytics;
-
 import org.exoplatform.R;
 import org.exoplatform.base.BaseActivity;
 import org.exoplatform.base.BaseActivity.BasicActivityLifecycleCallbacks;
@@ -32,6 +30,7 @@ import org.exoplatform.ui.login.tasks.CheckAccountExistsTask;
 import org.exoplatform.ui.login.tasks.CheckingTenantStatusTask;
 import org.exoplatform.ui.login.tasks.LoginTask;
 import org.exoplatform.ui.login.tasks.RequestTenantTask;
+import org.exoplatform.utils.CrashUtils;
 import org.exoplatform.utils.ExoConnectionUtils;
 import org.exoplatform.utils.ExoConstants;
 import org.exoplatform.utils.ExoUtils;
@@ -496,8 +495,8 @@ public class LoginProxy implements CheckingTenantStatusTask.AsyncTaskListener, R
       SettingUtils.persistServerSetting(mContext);
 
       // Set Crashlytics user information
-      Crashlytics.setUserName(mNewUserName);
-      Crashlytics.setString("ServerDomain", mDomain);
+      CrashUtils.setUsername(mNewUserName);
+      CrashUtils.setServerDomain(mDomain);
       break;
     }
 

--- a/src/org/exoplatform/ui/login/LoginProxy.java
+++ b/src/org/exoplatform/ui/login/LoginProxy.java
@@ -496,7 +496,8 @@ public class LoginProxy implements CheckingTenantStatusTask.AsyncTaskListener, R
 
       // Set Crashlytics user information
       CrashUtils.setUsername(mNewUserName);
-      CrashUtils.setServerDomain(mDomain);
+      CrashUtils.setServerInfo(mDomain, ServerSettingHelper.getInstance().getServerVersion());
+      
       break;
     }
 

--- a/src/org/exoplatform/ui/social/ActivityStreamFragment.java
+++ b/src/org/exoplatform/ui/social/ActivityStreamFragment.java
@@ -122,6 +122,7 @@ public abstract class ActivityStreamFragment extends Fragment {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    setRetainInstance(true);
     onPrepareLoad(ExoConstants.NUMBER_OF_ACTIVITY, false, 0);
   }
 
@@ -197,10 +198,7 @@ public abstract class ActivityStreamFragment extends Fragment {
         ArrayList<SocialActivityInfo> list = SocialServiceHelper.getInstance().getSocialListForTab(currentTab);
         mLoadTask = getThisLoadTask();
 
-        Log.d(TAG, "loading more data - flush image cache");
-        // ((SocialTabsActivity)
-        // getActivity()).getGDApplication().getImageCache().flush();
-        System.gc();
+        Log.i(TAG, "Loading more activities");
 
         if (list != null) { // if we can identify the last activity, we load the
                             // previous/older ones

--- a/src/org/exoplatform/ui/social/SocialDetailActivity.java
+++ b/src/org/exoplatform/ui/social/SocialDetailActivity.java
@@ -43,6 +43,7 @@ import android.widget.TextView;
  * Screen for activity details
  */
 public class SocialDetailActivity extends Activity implements OnClickListener {
+  
   public LinearLayout                startScreen;
 
   private View                       emptyCommentStubView;
@@ -78,17 +79,22 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
     socialDetailActivity = this;
     currentPosition = getIntent().getIntExtra(ExoConstants.ACTIVITY_CURRENT_POSITION, currentPosition);
     changeLanguage();
-    if (savedInstanceState != null)
-      finish();
-    else
-      initComponent();
+    initComponent();
+    onLoad();
+  }
+  
+  @Override
+  protected void onDestroy() {
+    if (detailController != null) {
+      detailController.onCancelLoad();
+    }
+    socialDetailActivity = null;
+    super.onDestroy();
   }
 
   private void initComponent() {
-
     startScreen = (LinearLayout) findViewById(R.id.details_start_screen);
     commentLayoutWrap = (LinearLayout) findViewById(R.id.activity_display_comment_wrap);
-
     contentDetailLayout = (LinearLayout) findViewById(R.id.social_detail_wrap_layout);
     likedLayoutWrap = (LinearLayout) findViewById(R.id.social_detail_like_wrap);
     textView_Like_Count = (TextView) findViewById(R.id.textView_Like_Count);
@@ -101,8 +107,6 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
     likeButton.setOnClickListener(this);
     likedFrame = (RelativeLayout) findViewById(R.id.detail_likers_layout_wrapper);
     likedFrame.setOnClickListener(this);
-    onLoad();
-
   }
 
   public void onLoad() {
@@ -113,14 +117,6 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
                                                   contentDetailLayout,
                                                   textView_Like_Count);
     detailController.onLoad(false, currentPosition);
-  }
-
-  @Override
-  public void finish() {
-    if (detailController != null) {
-      detailController.onCancelLoad();
-    }
-    super.finish();
   }
 
   @Override
@@ -155,7 +151,6 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
     if (view.equals(likeButton)) {
       detailController.onLikePress(currentPosition);
     }
-
     if (view.equals(likedFrame)) {
       detailController.onClickLikesFrame();
     }
@@ -184,5 +179,4 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
     yourCommentText = resource.getString(R.string.YourComment);
     commentEmptyString = resource.getString(R.string.EmptyComment);
   }
-
 }

--- a/src/org/exoplatform/ui/social/SocialDetailActivity.java
+++ b/src/org/exoplatform/ui/social/SocialDetailActivity.java
@@ -137,7 +137,8 @@ public class SocialDetailActivity extends Activity implements OnClickListener {
   public boolean onCreateOptionsMenu(Menu menu) {
     getMenuInflater().inflate(R.menu.activity_detail, menu);
     MenuItem loader = menu.findItem(R.id.menu_act_detail_refresh);
-    detailController.setLoaderItem(loader);
+    if (detailController != null)
+      detailController.setLoaderItem(loader);
     ExoUtils.setLoadingItem(loader, true);
     return super.onCreateOptionsMenu(menu);
   }

--- a/src/org/exoplatform/utils/CrashUtils.java
+++ b/src/org/exoplatform/utils/CrashUtils.java
@@ -3,12 +3,15 @@ package org.exoplatform.utils;
 import com.crashlytics.android.Crashlytics;
 
 import android.graphics.BitmapFactory;
+import android.util.Log;
 
 public class CrashUtils {
 
   private static final String KEY_USERNAME = "UserName";
   
-  private static final String KEY_SERVER = "Server Domain";
+  private static final String KEY_SERVER_DOMAIN = "Server Domain";
+  
+  private static final String KEY_SERVER_VERSION = "Server Version";
   
   private static final String KEY_IMAGE_HEIGHT = "Height Before Shrink";
   
@@ -22,8 +25,9 @@ public class CrashUtils {
     Crashlytics.setString(KEY_USERNAME, username);
   }
   
-  public static void setServerDomain(String domain) {
-    Crashlytics.setString(KEY_SERVER, domain);
+  public static void setServerInfo(String domain, String version) {
+    Crashlytics.setString(KEY_SERVER_DOMAIN, domain);
+    Crashlytics.setString(KEY_SERVER_VERSION, version);
   }
   
   public static void setShrinkInfo(BitmapFactory.Options options) {
@@ -32,9 +36,9 @@ public class CrashUtils {
       Crashlytics.setInt(KEY_IMAGE_WIDTH, options.outWidth);
       Crashlytics.setInt(KEY_SHRINK_RATIO, options.inSampleSize);
     } else {
-      Crashlytics.setInt(KEY_IMAGE_HEIGHT, -1);
-      Crashlytics.setInt(KEY_IMAGE_WIDTH, -1);
-      Crashlytics.setInt(KEY_SHRINK_RATIO, -1);
+      Crashlytics.setInt(KEY_IMAGE_HEIGHT, 0);
+      Crashlytics.setInt(KEY_IMAGE_WIDTH, 0);
+      Crashlytics.setInt(KEY_SHRINK_RATIO, 0);
     }
   }
   
@@ -44,6 +48,10 @@ public class CrashUtils {
   
   public static void setString(String key, String value) {
     Crashlytics.setString(key, value);
+  }
+  
+  public static void loge(String tag, String message) {
+    Crashlytics.log(Log.ERROR, tag, message);
   }
   
 }

--- a/src/org/exoplatform/utils/CrashUtils.java
+++ b/src/org/exoplatform/utils/CrashUtils.java
@@ -1,0 +1,49 @@
+package org.exoplatform.utils;
+
+import com.crashlytics.android.Crashlytics;
+
+import android.graphics.BitmapFactory;
+
+public class CrashUtils {
+
+  private static final String KEY_USERNAME = "UserName";
+  
+  private static final String KEY_SERVER = "Server Domain";
+  
+  private static final String KEY_IMAGE_HEIGHT = "Height Before Shrink";
+  
+  private static final String KEY_IMAGE_WIDTH = "Width Before Shrink";
+  
+  private static final String KEY_SHRINK_RATIO = "Shrink Ratio";
+  
+  private static final String KEY_IMAGE_SIZE = "Resize Image With Size KB";
+  
+  public static void setUsername(String username) {
+    Crashlytics.setString(KEY_USERNAME, username);
+  }
+  
+  public static void setServerDomain(String domain) {
+    Crashlytics.setString(KEY_SERVER, domain);
+  }
+  
+  public static void setShrinkInfo(BitmapFactory.Options options) {
+    if (options != null) {
+      Crashlytics.setInt(KEY_IMAGE_HEIGHT, options.outHeight);
+      Crashlytics.setInt(KEY_IMAGE_WIDTH, options.outWidth);
+      Crashlytics.setInt(KEY_SHRINK_RATIO, options.inSampleSize);
+    } else {
+      Crashlytics.setInt(KEY_IMAGE_HEIGHT, -1);
+      Crashlytics.setInt(KEY_IMAGE_WIDTH, -1);
+      Crashlytics.setInt(KEY_SHRINK_RATIO, -1);
+    }
+  }
+  
+  public static void setResizeInfo(int imageSize) {
+    Crashlytics.setInt(KEY_IMAGE_SIZE, imageSize / 1024);
+  }
+  
+  public static void setString(String key, String value) {
+    Crashlytics.setString(key, value);
+  }
+  
+}

--- a/src/org/exoplatform/utils/CrashUtils.java
+++ b/src/org/exoplatform/utils/CrashUtils.java
@@ -21,6 +21,8 @@ public class CrashUtils {
   
   private static final String KEY_IMAGE_SIZE = "Resize Image With Size KB";
   
+  private static final String KEY_OPEN_FILE_TYPE = "File Open Type";
+  
   public static void setUsername(String username) {
     Crashlytics.setString(KEY_USERNAME, username);
   }
@@ -45,6 +47,14 @@ public class CrashUtils {
   public static void setResizeInfo(int imageSize) {
     Crashlytics.setInt(KEY_IMAGE_SIZE, imageSize / 1024);
   }
+  
+  public static void setOpenFileType(String mimeType) {
+    Crashlytics.setString(KEY_OPEN_FILE_TYPE, mimeType);
+  }
+  
+  /*
+   * Generic Methods
+   */
   
   public static void setString(String key, String value) {
     Crashlytics.setString(key, value);

--- a/src/org/exoplatform/utils/ExoConnectionUtils.java
+++ b/src/org/exoplatform/utils/ExoConnectionUtils.java
@@ -44,16 +44,15 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
 import org.exoplatform.singleton.AccountSetting;
 import org.exoplatform.singleton.DocumentHelper;
 import org.exoplatform.singleton.ServerSettingHelper;
 import org.exoplatform.singleton.SocialServiceHelper;
 import org.exoplatform.ui.login.tasks.LogoutTask;
 import org.exoplatform.utils.image.ExoPicasso;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
-
-import com.crashlytics.android.Crashlytics;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
@@ -604,8 +603,8 @@ public class ExoConnectionUtils {
     // Clear all social service data
     SocialServiceHelper.getInstance().clearData();
     // Remove Crashlytics user information
-    Crashlytics.setUserName("");
-    Crashlytics.setString("ServerDomain", "");
+    CrashUtils.setUsername("");
+    CrashUtils.setServerDomain("");
   }
 
 }

--- a/src/org/exoplatform/utils/ExoConnectionUtils.java
+++ b/src/org/exoplatform/utils/ExoConnectionUtils.java
@@ -574,14 +574,16 @@ public class ExoConnectionUtils {
   }
 
   public static void setCookieStore(CookieStore cookieStore, ArrayList<String> list) {
-    cookieStore = new BasicCookieStore();
-    for (String cookieStr : list) {
-      String[] keyValue = cookieStr.split("=");
-      String key = keyValue[0];
-      String value = "";
-      if (keyValue.length > 1)
-        value = keyValue[1];
-      cookieStore.addCookie(new BasicClientCookie(key, value));
+    if (list != null) {
+      cookieStore = new BasicCookieStore();
+      for (String cookieStr : list) {
+        String[] keyValue = cookieStr.split("=");
+        String key = keyValue[0];
+        String value = "";
+        if (keyValue.length > 1)
+          value = keyValue[1];
+        cookieStore.addCookie(new BasicClientCookie(key, value));
+      }
     }
   }
 

--- a/src/org/exoplatform/utils/ExoConnectionUtils.java
+++ b/src/org/exoplatform/utils/ExoConnectionUtils.java
@@ -606,7 +606,7 @@ public class ExoConnectionUtils {
     SocialServiceHelper.getInstance().clearData();
     // Remove Crashlytics user information
     CrashUtils.setUsername("");
-    CrashUtils.setServerDomain("");
+    CrashUtils.setServerInfo("", "");
   }
 
 }

--- a/src/org/exoplatform/utils/ExoConnectionUtils.java
+++ b/src/org/exoplatform/utils/ExoConnectionUtils.java
@@ -574,8 +574,8 @@ public class ExoConnectionUtils {
   }
 
   public static void setCookieStore(CookieStore cookieStore, ArrayList<String> list) {
+    cookieStore = new BasicCookieStore();
     if (list != null) {
-      cookieStore = new BasicCookieStore();
       for (String cookieStr : list) {
         String[] keyValue = cookieStr.split("=");
         String key = keyValue[0];

--- a/src/org/exoplatform/utils/ExoDocumentUtils.java
+++ b/src/org/exoplatform/utils/ExoDocumentUtils.java
@@ -54,6 +54,8 @@ import org.exoplatform.model.ExoFile;
 import org.exoplatform.singleton.AccountSetting;
 import org.exoplatform.singleton.DocumentHelper;
 import org.exoplatform.ui.WebViewActivity;
+import org.exoplatform.utils.CompatibleFileOpen.FileOpenRequest;
+import org.exoplatform.utils.CompatibleFileOpen.FileOpenRequestResult;
 import org.exoplatform.widget.UnreadableFileDialog;
 
 import android.content.ComponentName;
@@ -172,23 +174,26 @@ public class ExoDocumentUtils {
    * installed application
    */
 
-  public static void fileOpen(Context context, String fileType, String filePath, String fileName) {
+  public static FileOpenRequest fileOpen(Context context, String fileType, String filePath, String fileName) {
+    FileOpenRequest result = new FileOpenRequest();
     if (fileType == null) {
       new UnreadableFileDialog(context, null).show();
-      return;
-    }
-
-    if (fileType.startsWith(IMAGE_TYPE) || fileType.startsWith(TEXT_TYPE)) {
+      result.mResult = FileOpenRequestResult.ERROR;
+    } else if (fileType.startsWith(IMAGE_TYPE) || fileType.startsWith(TEXT_TYPE)) {
       Intent intent = new Intent(context, WebViewActivity.class);
       intent.putExtra(ExoConstants.WEB_VIEW_URL, filePath);
       intent.putExtra(ExoConstants.WEB_VIEW_TITLE, fileName);
       intent.putExtra(ExoConstants.WEB_VIEW_MIME_TYPE, fileType);
       intent.putExtra(ExoConstants.WEB_VIEW_ALLOW_JS, "false");
       context.startActivity(intent);
+      result.mResult = FileOpenRequestResult.WEBVIEW;
     } else {
-      new CompatibleFileOpen(context, fileType, filePath, fileName);
+      result.mFileOpenController = new CompatibleFileOpen(context, fileType, filePath, fileName);
+      result.mResult = FileOpenRequestResult.EXTERNAL;
     }
-
+    if (Log.LOGD)
+      Log.d(LOG_TAG, "File Open Result: "+result.mResult);
+    return result;
   }
 
   /**

--- a/src/org/exoplatform/utils/PhotoUtils.java
+++ b/src/org/exoplatform/utils/PhotoUtils.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
+
 import org.exoplatform.utils.image.FileCache;
 
 import android.app.Activity;
@@ -138,14 +139,14 @@ public class PhotoUtils {
   }
 
   public static Bitmap shrinkBitmap(String file, int width, int height) {
-
+    
     BitmapFactory.Options bmpFactoryOptions = new BitmapFactory.Options();
     bmpFactoryOptions.inJustDecodeBounds = true;
     Bitmap bitmap = BitmapFactory.decodeFile(file, bmpFactoryOptions);
-
+    
     int heightRatio = (int) Math.ceil(bmpFactoryOptions.outHeight / (float) height);
     int widthRatio = (int) Math.ceil(bmpFactoryOptions.outWidth / (float) width);
-
+    
     if (heightRatio > 1 || widthRatio > 1) {
       if (heightRatio > widthRatio) {
         bmpFactoryOptions.inSampleSize = heightRatio;
@@ -154,8 +155,19 @@ public class PhotoUtils {
       }
     }
 
+    if ("image/jpeg".equalsIgnoreCase(bmpFactoryOptions.outMimeType)) {
+      bmpFactoryOptions.inPreferredConfig = Bitmap.Config.RGB_565;
+      bmpFactoryOptions.inDither = true;
+    } else {
+      bmpFactoryOptions.inPreferredConfig = Bitmap.Config.ARGB_8888;
+    }
     bmpFactoryOptions.inJustDecodeBounds = false;
+    
+    CrashUtils.setShrinkInfo(bmpFactoryOptions);
+    
     bitmap = BitmapFactory.decodeFile(file, bmpFactoryOptions);
+    
+    CrashUtils.setShrinkInfo(null);
     return bitmap;
   }
 
@@ -172,6 +184,8 @@ public class PhotoUtils {
       float scaleWidth = ((float) newW) / width;
 
       float scaleHeight = scaleWidth;
+      
+      CrashUtils.setResizeInfo(originalImage.getByteCount());
 
       Matrix matrix = new Matrix();
 
@@ -180,12 +194,11 @@ public class PhotoUtils {
       resizedBitmap = Bitmap.createBitmap(originalImage,
                                           0,
                                           0,
-
                                           width,
                                           height,
                                           matrix,
                                           true);
-
+      CrashUtils.setResizeInfo(-1);
     } else
       return originalImage;
     return resizedBitmap;

--- a/src/org/exoplatform/utils/SocialActivityUtil.java
+++ b/src/org/exoplatform/utils/SocialActivityUtil.java
@@ -360,11 +360,9 @@ public class SocialActivityUtil {
       try {
         Spannable spannable = (Spannable) textView.getText();
         for (URLSpan span : list) {
-
           int start = spannable.getSpanStart(span);
           int stop = spannable.getSpanEnd(span);
-          // TODO error here? should be spannable getSpanFlag ? 
-          int flags = spannable.getSpanEnd(span);
+          int flags = spannable.getSpanFlags(span);
           String spanUrl = span.getURL();
           spannable.removeSpan(span);
           TextUrlSpan myUrlSpan = null;

--- a/src/org/exoplatform/utils/SocialActivityUtil.java
+++ b/src/org/exoplatform/utils/SocialActivityUtil.java
@@ -378,8 +378,8 @@ public class SocialActivityUtil {
         }
       } catch (ClassCastException e) {
         // textView.getText() can fail to be casted to Spannable
-        if (Log.LOGE)
-          Log.e("eXo__SocialActivityUtil__", e.getMessage(), e);
+        if (Log.LOGD)
+          Log.d("eXo__SocialActivityUtil__", e.getMessage());
       }
     }
   }

--- a/src/org/exoplatform/widget/DocumentWaitingDialog.java
+++ b/src/org/exoplatform/widget/DocumentWaitingDialog.java
@@ -31,7 +31,8 @@ public class DocumentWaitingDialog extends WaitingDialog {
   @Override
   public void onBackPressed() {
     super.onBackPressed();
-    DocumentActivity._documentActivityInstance.onCancelLoad();
+    if (DocumentActivity._documentActivityInstance != null)
+      DocumentActivity._documentActivityInstance.onCancelLoad();
   }
 
 }

--- a/src/org/exoplatform/widget/WaitingDialog.java
+++ b/src/org/exoplatform/widget/WaitingDialog.java
@@ -26,7 +26,10 @@ import android.view.Window;
 import android.widget.TextView;
 
 public class WaitingDialog extends Dialog {
-  private TextView contentView;
+  
+  private boolean mIsAttachedToWindow;
+  
+  private TextView mContentView;
 
   public WaitingDialog(Context context, String titleString, String contentString) {
     super(context);
@@ -36,8 +39,24 @@ public class WaitingDialog extends Dialog {
       setTitle(titleString);
     }
     setContentView(R.layout.waiting_dialog_layout);
-    contentView = (TextView) findViewById(R.id.waiting_content);
-    contentView.setText(contentString);
+    mContentView = (TextView) findViewById(R.id.waiting_content);
+    mContentView.setText(contentString);
+  }
+  
+  public boolean isAttachedToWindow() {
+    return mIsAttachedToWindow;
+  }
+
+  @Override
+  public void onDetachedFromWindow() {
+    mIsAttachedToWindow = false;
+    super.onDetachedFromWindow();
+  }
+  
+  @Override
+  public void onAttachedToWindow() {
+    mIsAttachedToWindow = true;
+    super.onAttachedToWindow();
   }
 
   @Override
@@ -47,6 +66,6 @@ public class WaitingDialog extends Dialog {
   }
 
   public void setMessage(String message) {
-    contentView.setText(message);
+    mContentView.setText(message);
   }
 }


### PR DESCRIPTION
Most crashes occurred because of incorrect state after rotating the device.
OOM was fixed by reducing the quality of the image preview.